### PR TITLE
Fix “Server … answered 'GreenSocket' object does not support the context manager protocol”

### DIFF
--- a/eventlib/greenio.py
+++ b/eventlib/greenio.py
@@ -389,6 +389,13 @@ class GreenSocket(object):
     def gettimeout(self):
         return self.timeout
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
 def read(self, size=None):
     if size is not None and not isinstance(size, int):
         raise TypeError('Expecting an int or long for size, got %s: %s' % (type(size), repr(size)))


### PR DESCRIPTION
That error seemed to creep up somewhere out of name resolution while connecting, producing `notifications_trace.txt` logs like this:

```
2026-01-23 00:03:37.081538: Notification name=DNSLookupTrace sender=<sipsimple.lookup.DNSLookup object at 0x77924ac861c0> data=NotificationData(query_type='NAPTR', query_name='sip.zadarma.com', nameservers=['127.0.0.53'], answer=None, error=LifetimeTimeout("The resolution lifetime expired after 31.129 seconds: Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol; Server Do53:127.0.0.53@53 answered 'GreenSocket' object does not support the context manager protocol"), context='lookup_sip_proxy', uri=SIPURI(b'sip.zadarma.com', None, None, None, False, {}, {}), request_id=None)
```

Not using an ancient copy of eventlet would have likely avoided this from the beginning.